### PR TITLE
script: increment certificate serial number

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ This is SSL, so you'll need an cert-key pair for you/the server, the api users/t
     openssl req -new -key client.key -out client.csr
     
     # Sign the client certificate with our CA cert.  Unlike signing our own server cert, this is what we want to do.
-    openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
+    openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 02 -out client.crt
 
 
 ## Configuring nginx ##


### PR DESCRIPTION
Same serial on Firefox causes connection error (if you first imported client's certificate and then try to import server's one) or obscure message ["The PKCS #12 operation failed for unknown reasons."](https://duckduckgo.com/?q=%22The+PKCS+%2312+operation+failed+for+unknown+reasons.%22) (when server's certificate is imported first and you try to import client's one in FF Certificate Manager).

Your blog entry is quite high in search results for "client side certificate nginx" so I think that it's worth fixing.